### PR TITLE
Use correct index for adding preamble in shader source

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ where
             if shader_defs.is_some() {
                 if let Some(version) = source.find(r##"#version"##) {
                     if let Some(newline) = &source[version..].find('\n') {
-                        source.insert_str(newline + 1, &preamble);
+                        source.insert_str(version + newline + 1, &preamble);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3 

This should also fix the incorrect shader generation issue for `shader_defs` example in `bevyengine/bevy`