### PR TITLE
link c++ stdlib

### DIFF
--- a/glsl-to-spirv-builder/build.rs
+++ b/glsl-to-spirv-builder/build.rs
@@ -38,6 +38,12 @@ fn main() {
     if target.ends_with("-pc-windows-gnu") {
         println!("cargo:rustc-link-lib=dylib=stdc++");
     }
+
+    if target.contains("darwin") {
+        println!("cargo:rustc-link-lib={}", "c++");
+    } else if target.contains("linux") {
+        println!("cargo:rustc-link-lib={}", "stdc++");
+    }
 }
 
 #[cfg(feature = "build-from-source")]


### PR DESCRIPTION
Otherwise glsl-to-spirv failes to compile if `spirv-reflect` is not compiled.
See https://github.com/bevyengine/bevy/pull/2130#issuecomment-835215342

I only tested this on linux.